### PR TITLE
Fixed encoding issues in REST deserialize function in Python 3

### DIFF
--- a/germanium/rest.py
+++ b/germanium/rest.py
@@ -72,7 +72,7 @@ class RESTTestCase(ClientTestCase, AssertMixin):
         Given a ``HttpResponse`` coming back from using the ``client``, this method
         return dict of deserialized json string
         """
-        return json.loads(resp.content)
+        return json.loads(resp.content.decode('utf-8'))
 
     def serialize(self, data):
         """


### PR DESCRIPTION
There were encoding issues with the deserialize function under Python 3.